### PR TITLE
update to 1.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx4G
 # Fabric Properties
-# check this on https://fabricmc.net/versions.html
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.5
-loader_version=0.14.12
+# check this on https://fabricmc.net/develop/
+minecraft_version=1.20
+yarn_mappings=1.20+build.1
+loader_version=0.15.3
 # Mod Properties
-mod_version=3.2.1
+mod_version=3.2.2
 maven_group=com.vlad2305m
 archives_base_name=proper-mobcap-modifier
 # Dependencies
-# check this on https://fabricmc.net/versions.html
-fabric_version=0.72.0+1.19.3
-# https://www.curseforge.com/minecraft/mc-mods/cloth-config/files
-cloth_config_version=9.0.94
-# https://www.curseforge.com/minecraft/mc-mods/modmenu/files
-mod_menu_version=5.0.2
+# check this on https://fabricmc.net/develop/
+fabric_version=0.83.0+1.20
+# https://modrinth.com/mod/cloth-config/versions?l=fabric
+cloth_config_version=11.1.118
+# https://modrinth.com/mod/modmenu/versions
+mod_menu_version=7.0.1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,6 @@
   "depends": {
     "cloth-config2": ">=7.0.0",
     "fabricloader": ">=0.14.6",
-    "minecraft": "1.19.*"
+    "minecraft": ">=1.20"
   }
 }


### PR DESCRIPTION
it didn't really need it, a version override would've been enough, but Aternos for some reason doesn't allow you to install mods that aren't listed for the version you are running 
set the minecraft requirement to >=1.20 as well so after testing if it still works you can just add the minecraft version to the mod version on CF

really cool how you've made such a basic mod that does exactly what it needs to and is basically timeless even though recent minecraft updates try to break every mod out there

hope I did the mod version increment correctly

edit: ~~I spoke to soon, the entity mixin breaks on 20.4, I'll see where it breaks and create more versions~~
nevermind, it's just mixinextras missing in the dev env, it's included in the fabric loader from 015